### PR TITLE
Refactor screens into objects

### DIFF
--- a/adhop.py
+++ b/adhop.py
@@ -2,13 +2,13 @@ import sys
 import pygame
 
 import flags
-import setup
+import init
 from adventure import choose_adventure, start_adventure
 from mission import Mission
 
 def main():
     """Run the game."""
-    flags.setup_flags("Adorable Hopelessness RPG.")
+    flags.init_flags("Adorable Hopelessness RPG.")
 
     # Initialize game and create a screen object.
     pygame.init()
@@ -18,17 +18,17 @@ def main():
     bg_color = (230, 230, 230)
 
     # Set player name
-    avatar = setup.set_player_name(screen, bg_color)
+    avatar = init.set_player_name(screen, bg_color)
 
     stats = {'wins': 0, 'losses': 0, 'retreats': 0}
 
     # Create mission list
-    missions = setup.setup_missions()
+    missions = init.init_missions()
 
     # Loop ready / results
     while True:
         # Ready to adventure?
-        setup.player_ready(screen, bg_color)
+        init.player_ready(screen, bg_color)
 
         # Choose an adventure
         mission = choose_adventure(screen, bg_color, missions)

--- a/adhop.py
+++ b/adhop.py
@@ -3,6 +3,7 @@ import pygame
 
 import flags
 import init
+import screen
 from adventure import choose_adventure, start_adventure
 from mission import Mission
 
@@ -28,7 +29,7 @@ def main():
     # Loop ready / results
     while True:
         # Ready to adventure?
-        init.player_ready(bg_surface, bg_color)
+        screen.ReadyScreen(bg_surface, bg_color).run()
 
         # Choose an adventure
         mission = choose_adventure(bg_surface, bg_color, missions)

--- a/adhop.py
+++ b/adhop.py
@@ -10,15 +10,15 @@ def main():
     """Run the game."""
     flags.init_flags("Adorable Hopelessness RPG.")
 
-    # Initialize game and create a screen object.
+    # Initialize game and create a background surface object.
     pygame.init()
-    screen = pygame.display.set_mode((600,400))
+    bg_surface = pygame.display.set_mode((600,400))
     pygame.display.set_caption("Adorable Hopelessness")
 
     bg_color = (230, 230, 230)
 
     # Set player name
-    avatar = init.set_player_name(screen, bg_color)
+    avatar = init.set_player_name(bg_surface, bg_color)
 
     stats = {'wins': 0, 'losses': 0, 'retreats': 0}
 
@@ -28,13 +28,13 @@ def main():
     # Loop ready / results
     while True:
         # Ready to adventure?
-        init.player_ready(screen, bg_color)
+        init.player_ready(bg_surface, bg_color)
 
         # Choose an adventure
-        mission = choose_adventure(screen, bg_color, missions)
+        mission = choose_adventure(bg_surface, bg_color, missions)
 
         # Run adventure
-        start_adventure(screen, bg_color, stats, avatar, mission)
+        start_adventure(bg_surface, bg_color, stats, avatar, mission)
 
 
 main()

--- a/adventure.py
+++ b/adventure.py
@@ -5,14 +5,14 @@ import pygame
 
 from stats import draw_stats
 
-def choose_adventure(screen, bg_color, missions):
+def choose_adventure(bg_surface, bg_color, missions):
     text_color = (0, 0, 0)
     heading_font = pygame.font.SysFont(None, 42)
     title_font = pygame.font.SysFont(None, 36)
 
     heading_msg = "Choose an Adventure"
     
-    # Render heading_msg, position at 0,0 (default), and draw to surface
+    # Render heading_msg
     heading_msg_image = heading_font.render(heading_msg, True, text_color)
     heading_msg_image_rect = heading_msg_image.get_rect()
 
@@ -40,8 +40,8 @@ def choose_adventure(screen, bg_color, missions):
     surface = pygame.Surface((heading_msg_image_rect.width,
                              last_msg_bottom))
     surface_rect = surface.get_rect()
-    screen_rect = screen.get_rect()
-    surface_rect.center = screen_rect.center
+    bg_surface_rect = bg_surface.get_rect()
+    surface_rect.center = bg_surface_rect.center
 
     while True:
         for event in pygame.event.get():
@@ -57,24 +57,23 @@ def choose_adventure(screen, bg_color, missions):
                     if rect.collidepoint(pygame.mouse.get_pos()):
                         return title_msg['mission']
 
-        screen.fill(bg_color)
+        bg_surface.fill(bg_color)
         # Have to use background color, not surface.set_alpha(0)
         # See https://github.com/renpy/pygame_sdl2/issues/24
         surface.fill(bg_color)
 
         # Draw text on surface
-        #surface.blit(heading_msg_image, heading_msg_image_rect)
         surface.blit(heading_msg_image, (0,0))
         for title_msg in title_msgs:
             surface.blit(title_msg['image'], title_msg['rect'])
 
-        # Draw surface to screen
-        screen.blit(surface, surface_rect)
+        # Draw surface to bg_surface
+        bg_surface.blit(surface, surface_rect)
 
         pygame.display.flip()
 
 
-def start_adventure(screen, bg_color, stats, avatar, mission):
+def start_adventure(bg_surface, bg_color, stats, avatar, mission):
     """Start a new adventure."""
     # Avatar and enemy start with full hp.
     avatar.heal()
@@ -101,21 +100,21 @@ def start_adventure(screen, bg_color, stats, avatar, mission):
             elif event.type == pygame.KEYDOWN:
                 return
 
-        # Draw screen objects.
-        screen.fill(bg_color)
-        draw_stats(screen, stats)
-        draw_results(screen, avatar, mission)
+        # Draw objects.
+        bg_surface.fill(bg_color)
+        draw_stats(bg_surface, stats)
+        draw_results(bg_surface, avatar, mission)
 
-        # Make the most recently drawn screen visible.
+        # Make the most recently drawn bg_surface visible.
         pygame.display.flip()
 
 
-def draw_results(screen, avatar, mission):
+def draw_results(bg_surface, avatar, mission):
     """Draw the results of the last combat."""
     text_color = (0, 0, 0)
     title_font = pygame.font.SysFont(None, 42)
     result_font = pygame.font.SysFont(None, 36)
-    screen_rect = screen.get_rect()
+    bg_surface_rect = bg_surface.get_rect()
 
     if mission.result is None:
         result_msg = avatar.name + " withdrew."
@@ -126,26 +125,26 @@ def draw_results(screen, avatar, mission):
 
     hp_msg = avatar.name + " HP: " + str(avatar.hp)
 
-    # Render mission title and position slightly above center on the screen.
+    # Render mission title and position slightly above center on bg_surface.
     title_msg_image = title_font.render(mission.title, True, text_color)
     title_msg_image_rect = title_msg_image.get_rect()
-    title_msg_image_rect.centerx = screen_rect.centerx
-    title_msg_image_rect.bottom = screen_rect.centery - 5
+    title_msg_image_rect.centerx = bg_surface_rect.centerx
+    title_msg_image_rect.bottom = bg_surface_rect.centery - 5
 
-    # Render result_msg and position slightly below center on the creen.
+    # Render result_msg and position slightly below center on bg_surface.
     result_msg_image = result_font.render(result_msg, True, text_color)
     result_msg_image_rect = result_msg_image.get_rect()
-    result_msg_image_rect.centerx = screen_rect.centerx
-    result_msg_image_rect.top = screen_rect.centery + 5
+    result_msg_image_rect.centerx = bg_surface_rect.centerx
+    result_msg_image_rect.top = bg_surface_rect.centery + 5
 
-    # Render hp_msg and position below result_msg on the screen.
+    # Render hp_msg and position below result_msg on bg_surface.
     hp_msg_image = result_font.render(hp_msg, True, text_color)
     hp_msg_image_rect = hp_msg_image.get_rect()
-    hp_msg_image_rect.centerx = screen_rect.centerx
+    hp_msg_image_rect.centerx = bg_surface_rect.centerx
     hp_msg_image_rect.top = result_msg_image_rect.bottom + 5
 
     # Draw messages.
-    screen.blit(title_msg_image, title_msg_image_rect)
-    screen.blit(result_msg_image, result_msg_image_rect)
-    screen.blit(hp_msg_image, hp_msg_image_rect)
+    bg_surface.blit(title_msg_image, title_msg_image_rect)
+    bg_surface.blit(result_msg_image, result_msg_image_rect)
+    bg_surface.blit(hp_msg_image, hp_msg_image_rect)
 

--- a/flags.py
+++ b/flags.py
@@ -3,7 +3,7 @@
 import argparse
 import logging
 
-def setup_flags(description):
+def init_flags(description):
     """Enable standard flags."""
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument("-v", "--verbose", help="enable verbose logging",

--- a/init.py
+++ b/init.py
@@ -19,68 +19,68 @@ def init_missions():
     return missions
 
 
-def draw_name_prompt(screen):
+def draw_name_prompt(bg_surface):
     """Draw the prompt for name input."""
     text_color = (0, 0, 0)
     font = pygame.font.SysFont(None, 36)
-    screen_rect = screen.get_rect()
+    bg_surface_rect = bg_surface.get_rect()
 
     msg = "Name your character:"
 
-    # Render msg and position left of center on the screen.
+    # Render msg and position left of center on bg_surface.
     msg_image = font.render(msg, True, text_color)
     msg_image_rect = msg_image.get_rect()
-    msg_image_rect.right = screen_rect.centerx - 10
-    msg_image_rect.centery = screen_rect.centery
+    msg_image_rect.right = bg_surface_rect.centerx - 10
+    msg_image_rect.centery = bg_surface_rect.centery
 
     # Draw message.
-    screen.blit(msg_image, msg_image_rect)
+    bg_surface.blit(msg_image, msg_image_rect)
 
 
-def draw_name_input(screen, msg):
+def draw_name_input(bg_surface, msg):
     """Draw the name being input."""
     text_color = (0, 0, 0)
     font = pygame.font.SysFont(None, 36)
-    screen_rect = screen.get_rect()
+    bg_surface_rect = bg_surface.get_rect()
 
-    # Render msg and position right of center on the screen.
+    # Render msg and position right of center on bg_surface.
     msg_image = font.render(msg, True, text_color)
     msg_image_rect = msg_image.get_rect()
-    msg_image_rect.left = screen_rect.centerx + 10
-    msg_image_rect.centery = screen_rect.centery
+    msg_image_rect.left = bg_surface_rect.centerx + 10
+    msg_image_rect.centery = bg_surface_rect.centery
 
     # Draw message.
-    screen.blit(msg_image, msg_image_rect)
+    bg_surface.blit(msg_image, msg_image_rect)
 
 
-def draw_ready_question(screen):
+def draw_ready_question(bg_surface):
     """Draw the prompt for game readiness."""
-    screen_rect = screen.get_rect()
+    bg_surface_rect = bg_surface.get_rect()
 
-    # Render question and position in the center of the screen.
+    # Render question and position in the center of bg_surface.
     ready = "Are you ready to adventure?"
     ready_text_color = (0, 0, 0)
     ready_font = pygame.font.SysFont(None, 36)
     ready_image = ready_font.render(ready, True, ready_text_color)
     ready_image_rect = ready_image.get_rect()
-    ready_image_rect.center = screen_rect.center
+    ready_image_rect.center = bg_surface_rect.center
 
-    # Render instruction and position at the center bottom of the
-    # screen.
+    # Render instruction and position at the center bottom of
+    # bg_surface.
     inst = "Press SPACE to continue"
     inst_text_color = (100, 100, 100)
     inst_font = pygame.font.SysFont(None, 32)
     inst_image = inst_font.render(inst, True, inst_text_color)
     inst_image_rect = inst_image.get_rect()
-    inst_image_rect.centerx = screen_rect.centerx
-    inst_image_rect.bottom = screen_rect.bottom - 10
+    inst_image_rect.centerx = bg_surface_rect.centerx
+    inst_image_rect.bottom = bg_surface_rect.bottom - 10
 
     # Draw messages.
-    screen.blit(ready_image, ready_image_rect)
-    screen.blit(inst_image, inst_image_rect)
+    bg_surface.blit(ready_image, ready_image_rect)
+    bg_surface.blit(inst_image, inst_image_rect)
 
 
-def set_player_name(screen, bg_color):
+def set_player_name(bg_surface, bg_color):
     """Set player name.
 
     Returns:
@@ -106,16 +106,16 @@ def set_player_name(screen, bg_color):
                     avatar.log_properties()
                     return avatar
 
-        # Draw screen objects.
-        screen.fill(bg_color)
-        draw_name_prompt(screen)
-        draw_name_input(screen, name_input)
+        # Draw objects.
+        bg_surface.fill(bg_color)
+        draw_name_prompt(bg_surface)
+        draw_name_input(bg_surface, name_input)
 
-        # Make the most recently drawn screen visible.
+        # Make the most recently drawn bg_surface visible.
         pygame.display.flip()
 
 
-def player_ready(screen, bg_color):
+def player_ready(bg_surface, bg_color):
     """Ask player if ready to play."""
     while True:
         for event in pygame.event.get():
@@ -125,11 +125,11 @@ def player_ready(screen, bg_color):
                 if event.key == pygame.K_SPACE:
                     return
     
-        # Draw screen objects.
-        screen.fill(bg_color)
-        draw_ready_question(screen)
+        # Draw objects.
+        bg_surface.fill(bg_color)
+        draw_ready_question(bg_surface)
 
-        # Make the most recently drawn screen visible.
+        # Make the most recently drawn bg_surface visible.
         pygame.display.flip()
 
 

--- a/init.py
+++ b/init.py
@@ -53,33 +53,6 @@ def draw_name_input(bg_surface, msg):
     bg_surface.blit(msg_image, msg_image_rect)
 
 
-def draw_ready_question(bg_surface):
-    """Draw the prompt for game readiness."""
-    bg_surface_rect = bg_surface.get_rect()
-
-    # Render question and position in the center of bg_surface.
-    ready = "Are you ready to adventure?"
-    ready_text_color = (0, 0, 0)
-    ready_font = pygame.font.SysFont(None, 36)
-    ready_image = ready_font.render(ready, True, ready_text_color)
-    ready_image_rect = ready_image.get_rect()
-    ready_image_rect.center = bg_surface_rect.center
-
-    # Render instruction and position at the center bottom of
-    # bg_surface.
-    inst = "Press SPACE to continue"
-    inst_text_color = (100, 100, 100)
-    inst_font = pygame.font.SysFont(None, 32)
-    inst_image = inst_font.render(inst, True, inst_text_color)
-    inst_image_rect = inst_image.get_rect()
-    inst_image_rect.centerx = bg_surface_rect.centerx
-    inst_image_rect.bottom = bg_surface_rect.bottom - 10
-
-    # Draw messages.
-    bg_surface.blit(ready_image, ready_image_rect)
-    bg_surface.blit(inst_image, inst_image_rect)
-
-
 def set_player_name(bg_surface, bg_color):
     """Set player name.
 
@@ -113,23 +86,4 @@ def set_player_name(bg_surface, bg_color):
 
         # Make the most recently drawn bg_surface visible.
         pygame.display.flip()
-
-
-def player_ready(bg_surface, bg_color):
-    """Ask player if ready to play."""
-    while True:
-        for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                sys.exit()
-            elif event.type == pygame.KEYDOWN:
-                if event.key == pygame.K_SPACE:
-                    return
-    
-        # Draw objects.
-        bg_surface.fill(bg_color)
-        draw_ready_question(bg_surface)
-
-        # Make the most recently drawn bg_surface visible.
-        pygame.display.flip()
-
 

--- a/init.py
+++ b/init.py
@@ -6,7 +6,7 @@ from random import choice
 from actor import Avatar
 from mission import Mission
 
-def setup_missions():
+def init_missions():
     """Return list of missions."""
     # Create mission list
     missions = []

--- a/mission.py
+++ b/mission.py
@@ -68,7 +68,7 @@ class Mission():
 
 # Execute this only if running as a standalone
 if __name__ == "__main__":
-    flags.setup_flags("Combat mission test module.")
+    flags.init_flags("Combat mission test module.")
     avatar = Avatar()
     mission = Mission()
     logging.debug(mission.resolve_combat(avatar))

--- a/screen.py
+++ b/screen.py
@@ -33,7 +33,7 @@ class Screen():
         # Make the most recently drawn bg_surface visible.
         pygame.display.flip()
 
-    def catch_special_events(self):
+    def catch_special_events(self, event):
         """Overridable function for screen-specific events."""
         pass
 

--- a/screen.py
+++ b/screen.py
@@ -1,0 +1,95 @@
+"""Classes for modeling game screens."""
+
+import sys
+import pygame
+
+class Screen():
+    """A representation of a game screen."""
+
+    def __init__(self, bg_surface, bg_color):
+        """Initialize screen attributes."""
+        self.bg_surface = bg_surface
+        self.bg_color = bg_color
+
+        # Create screen in inactive state.
+        self.active = False
+
+    def catch_events(self):
+        """Catch common events and include events for specific screens."""
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                sys.exit()
+            else:
+                self.catch_special_events(event)
+
+    def display(self):
+        """Draw and display the screen."""
+        # Fill background color.
+        self.bg_surface.fill(self.bg_color)
+
+        # Draw objects.
+        self.draw_objects()
+
+        # Make the most recently drawn bg_surface visible.
+        pygame.display.flip()
+
+    def catch_special_events(self):
+        """Overridable function for screen-specific events."""
+        pass
+
+    def draw_objects(self):
+        """Overridable function for screen-specific objects."""
+        pass
+
+    def run(self):
+        """Run the screen's game loop."""
+        # Make the screen state active.
+        self.active = True
+
+        while self.active:
+            # Check for events.
+            self.catch_events()
+
+            # Draw the screen.
+            self.display()
+
+
+class ReadyScreen(Screen):
+    """The "ready to adventure" screen."""
+
+    def __init__(self, bg_surface, bg_color):
+        """Initialize screen attributes."""
+        super().__init__(bg_surface, bg_color)
+
+    def catch_special_events(self, event):
+        """Catch screen-specific events."""
+        if event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_SPACE:
+                self.active = False
+
+    def draw_objects(self):
+        """Draw the prompt for game readiness."""
+        bg_surface_rect = self.bg_surface.get_rect()
+
+        # Render question and position in the center of bg_surface.
+        ready = "Are you ready to adventure?"
+        ready_text_color = (0, 0, 0)
+        ready_font = pygame.font.SysFont(None, 36)
+        ready_image = ready_font.render(ready, True, ready_text_color)
+        ready_image_rect = ready_image.get_rect()
+        ready_image_rect.center = bg_surface_rect.center
+
+        # Render instruction and position at the center bottom of
+        # bg_surface.
+        inst = "Press SPACE to continue"
+        inst_text_color = (100, 100, 100)
+        inst_font = pygame.font.SysFont(None, 32)
+        inst_image = inst_font.render(inst, True, inst_text_color)
+        inst_image_rect = inst_image.get_rect()
+        inst_image_rect.centerx = bg_surface_rect.centerx
+        inst_image_rect.bottom = bg_surface_rect.bottom - 10
+
+        # Draw messages.
+        self.bg_surface.blit(ready_image, ready_image_rect)
+        self.bg_surface.blit(inst_image, inst_image_rect)
+

--- a/stats.py
+++ b/stats.py
@@ -2,7 +2,7 @@
 
 import pygame
 
-def draw_stats(screen, stats):
+def draw_stats(bg_surface, stats):
     """Draw running statistics of wins and losses."""
     text_color = (100, 100, 100)
     font = pygame.font.SysFont(None, 32)
@@ -29,7 +29,7 @@ def draw_stats(screen, stats):
     retreats_image_rect.left = 10
 
     # Draw stats.
-    screen.blit(wins_image, wins_image_rect)
-    screen.blit(losses_image, losses_image_rect)
-    screen.blit(retreats_image, retreats_image_rect)
+    bg_surface.blit(wins_image, wins_image_rect)
+    bg_surface.blit(losses_image, losses_image_rect)
+    bg_surface.blit(retreats_image, retreats_image_rect)
 


### PR DESCRIPTION
A bunch of this is renaming so we can reappropriate the word "screen" for sets of stuff we are displaying (ready screen, result screen) instead of the background surface.  (The former screen is now bg_surface.)

screen.py is new, for handling events and display with more shared code instead of massive functions for each screen.  This version only converts the ready screen as a first trial.